### PR TITLE
Add two configuration options to control the error panel and markers

### DIFF
--- a/cc.sublime-settings
+++ b/cc.sublime-settings
@@ -43,4 +43,10 @@
         "-isystem", "/usr/local/opt/llvm/include",
         "-Wall"
     ],
+
+    // do not show markers for warnings or errors on save.
+    "hide_error_mark": false,
+
+    // do not show the panel for warnings and errors on save.
+    "hide_error_panel": false,
 }

--- a/clang_error.py
+++ b/clang_error.py
@@ -64,7 +64,7 @@ class ClangErrorPanel(object):
         sublime.active_window().run_command("hide_panel", {"panel": "output.cc"})
 
 
-    def error_marks(self, view, digst):
+    def error_marks(self, view, digst, display):
         self.erase_error_marks(view)
 
         cur_filename = view.file_name()
@@ -74,21 +74,23 @@ class ClangErrorPanel(object):
             if error_type in outlines and cur_filename == filename:
                 outlines[error_type].append(view.full_line(view.text_point(line-1, 0)))
 
-        for line_type in outlines:
-            if not outlines[line_type] is None:
-                args = [
-                    'sublimeclang-outlines-{0}'.format(line_type),
-                    outlines[line_type],
-                    self.markers[line_type],
-                    'dot',
-                    sublime.DRAW_OUTLINED
-                ]
-                view.add_regions(*args)
+        if display:
+            for line_type in outlines:
+                if not outlines[line_type] is None:
+                    args = [
+                        'sublimeclang-outlines-{0}'.format(line_type),
+                        outlines[line_type],
+                        self.markers[line_type],
+                        'dot',
+                        sublime.DRAW_OUTLINED
+                    ]
+                    view.add_regions(*args)
 
 
     def erase_error_marks(self, view):
-        view.erase_regions('cc-outlines-error')
-        view.erase_regions('cc-outlines-warning')
+        view.erase_regions('sublimeclang-outlines-error')
+        view.erase_regions('sublimeclang-outlines-warning')
+        view.erase_regions('sublimeclang-outlines-fatal error')
 
 
 clang_error_panel = ClangErrorPanel()

--- a/st_cc.py
+++ b/st_cc.py
@@ -262,6 +262,9 @@ class CCAutoComplete(sublime_plugin.EventListener):
     if not can_complete(view):
       return 
 
+    settings = Complete.get_settings()
+    hide_error_panel = settings.get('hide_error_panel') or False
+    hide_error_mark = settings.get('hide_error_mark') or False
     file_name = view.file_name()
     sym = Complete.get_symbol(file_name, view)
     if self.dirty:
@@ -271,12 +274,12 @@ class CCAutoComplete(sublime_plugin.EventListener):
     
     output = "\n".join([err for _, (_, _, _, _, err) in digst])
     clang_error_panel.set_data(output)
-    clang_error_panel.error_marks(view, digst)
+    clang_error_panel.error_marks(view, digst, not hide_error_mark)
 
     print(output)
     window = view.window()
     if not window is None and len(digst) >= 1:
-      window.run_command("clang_toggle_panel", {"show": True})
+      window.run_command("clang_toggle_panel", {"show": not hide_error_panel})
 
   
   def on_query_completions(self, view, prefix, locations):


### PR DESCRIPTION
This change adds two configuration options in cc.sublime-settings
to control the display of error panel and markers.

hide_error_panel:
   If set to "true", the error panel will not be displayed
   automatically upon saving

hide_error_mark:
   If set to "true", the error markers will not be displayed
   upon saving.
