### PR TITLE
Fix error message, when there are no project-specific includes

### DIFF
--- a/st_cc.py
+++ b/st_cc.py
@@ -157,9 +157,11 @@ class Complete(object):
     settings = Complete.get_settings()
     additional_lang_opts = settings.get("additional_language_options", {})
     language = get_language(view)
+    include_opts = settings.get("include_options", [])
     project_data = sublime.active_window().project_data()
-    include_opts = settings.get("include_options", []) + project_data["cc_include_options"]
-    
+    if "cc_include_options" in project_data:
+      include_opts = include_opts + project_data["cc_include_options"]
+
     window = sublime.active_window()
     variables = window.extract_variables()
     include_opts = sublime.expand_variables(include_opts, variables)


### PR DESCRIPTION
If there are no "cc_include_options" in project settings, then python throws and exception to console.
This commit fixes this bug, which was introduced by my previous commit 092145e07d4aa4ad14abf85a27fb8de37ca25f40
