### PR TITLE
Exposed hide_error_panel and hide_error_mark in Sublime Project, so t…

### DIFF
--- a/st_cc.py
+++ b/st_cc.py
@@ -271,8 +271,9 @@ class CCAutoComplete(sublime_plugin.EventListener):
       return 
 
     settings = Complete.get_settings()
-    hide_error_panel = settings.get('hide_error_panel') or False
-    hide_error_mark = settings.get('hide_error_mark') or False
+    project_settings = view.settings()
+    hide_error_panel = settings.get('hide_error_panel') or project_settings.get('cc_hide_error_panel') or False
+    hide_error_mark = settings.get('hide_error_mark') or project_settings.get('cc_hide_error_mark') or False
     file_name = view.file_name()
     sym = Complete.get_symbol(file_name, view)
     if self.dirty:


### PR DESCRIPTION
…hey can be controlled on a per project basis.  Handy for cross development where the target's headers aren't liked by clang on the host platform.  For example a MacOS host editing files on a Windows Virtual Machine.
